### PR TITLE
Add package scanning tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 build/
 
+__pycache__/
+
 config.lua

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# Agent Instructions
+
+- This repository contains scripts to manage and scan Mudlet packages.
+- Use `scan_packages.py` to analyze packages in the `packages/` directory for risky Lua patterns.
+- The scan should stop after 10 matches and produce `scan_report.csv` with columns: package, file, line number, category, matched text, and context.
+- Do not mark packages as scanned; this repository is currently in testing.
+- When adding or modifying detection logic or hints, update this `AGENTS.md` and regenerate `scan_report.csv`.

--- a/scan_packages.py
+++ b/scan_packages.py
@@ -1,0 +1,81 @@
+import zipfile
+import re
+import csv
+import random
+from pathlib import Path
+
+PATTERNS = {
+    'Process Spawning': [r'\bos\.execute\b', r'\bio\.popen\b', r'\bspawn\b'],
+    'External Communications': [r'socket\.http', r'https?://'],
+    'Unsafe Inputs': [r'\bloadstring\b', r'\bdofile\b', r'\bloadfile\b'],
+}
+
+CONTEXT_LINES = 2
+MAX_MATCHES = 10
+
+
+def find_matches(text, regexes, remaining):
+    matches = []
+    lines = text.splitlines()
+    for idx, line in enumerate(lines, 1):
+        for category, regs in regexes.items():
+            for reg in regs:
+                m = re.search(reg, line)
+                if m:
+                    start = max(0, idx - CONTEXT_LINES - 1)
+                    end = min(len(lines), idx + CONTEXT_LINES)
+                    context = '\n'.join(lines[start:end])
+                    matches.append((idx, context, line.strip(), m.group(0), category))
+                    if len(matches) >= remaining:
+                        return matches
+    return matches
+
+
+def scan_package(path, remaining):
+    results = []
+    try:
+        with zipfile.ZipFile(path) as z:
+            for member in z.namelist():
+                if not member.lower().endswith('.lua'):
+                    continue
+                with z.open(member) as f:
+                    text = f.read().decode('utf-8', errors='ignore')
+                matches = find_matches(text, PATTERNS, remaining - len(results))
+                for idx, context, line, match, category in matches:
+                    results.append({
+                        'package': path.name,
+                        'file': member,
+                        'line_number': idx,
+                        'context': context,
+                        'matched': match,
+                        'category': category,
+                    })
+                    if len(results) >= remaining:
+                        return results
+    except zipfile.BadZipFile:
+        pass
+    return results
+
+
+def main():
+    pkg_dir = Path('packages')
+    package_files = list(pkg_dir.glob('*.mpackage')) + list(pkg_dir.glob('*.zip'))
+    random.shuffle(package_files)
+    results = []
+    for pkg in package_files:
+        remaining = MAX_MATCHES - len(results)
+        if remaining <= 0:
+            break
+        results.extend(scan_package(pkg, remaining))
+        if len(results) >= MAX_MATCHES:
+            break
+
+    with open('scan_report.csv', 'w', newline='', encoding='utf-8') as f:
+        writer = csv.DictWriter(f, fieldnames=['package', 'file', 'line_number', 'category', 'matched', 'context'])
+        writer.writeheader()
+        for row in results:
+            writer.writerow(row)
+
+
+if __name__ == '__main__':
+    main()

--- a/scan_report.csv
+++ b/scan_report.csv
@@ -1,0 +1,39 @@
+package,file,line_number,category,matched,context
+mapaddons-safe-delete.mpackage,config.lua,9,External Communications,https://,"
+---
+This package was originally shared on the [Mudlet Forums](https://forums.mudlet.org/viewtopic.php?f=6&t=22719&sid=f8b58b442e976180e3f6220553eccb8e) by the author. We’ve automatically listed it here on packages.mudlet.org so more users can discover and benefit from it. Please let us know if you have any questions or concerns - thanks for contributing to the Mudlet community!]]"
+monk-combo-script-achaea.mpackage,config.lua,9,External Communications,https://,"
+---
+This package was originally shared on the [Mudlet Forums](https://forums.mudlet.org/viewtopic.php?f=6&t=2581&sid=aa12bbf669d90e2a5a6be5d034a5a4ba) by the author. We’ve automatically listed it here on packages.mudlet.org so more users can discover and benefit from it. Please let us know if you have any questions or concerns - thanks for contributing to the Mudlet community!]]"
+ProgressDisplayinator.mpackage,config.lua,11,External Communications,https://,"Prolly works with other IREs too
+
+![image](https://github.com/demonnic/ProgressDisplayinator/assets/3660/3aed41fa-07eb-4cc3-a60b-fb9ba6a9ed11)
+
+"
+ProgressDisplayinator.mpackage,config.lua,16,External Communications,https://,"## Installation
+
+`lua uninstallPackage(""ProgressDisplayinator"") installPackage(""https://github.com/demonnic/ProgressDisplayinator/releases/latest/download/ProgressDisplayinator.mpackage"")`
+
+## Usage"
+getvalueat.mpackage,config.lua,9,External Communications,https://,"
+---
+This package was originally shared on the [Mudlet Forums](https://forums.mudlet.org/viewtopic.php?f=6&t=22762&sid=f8b58b442e976180e3f6220553eccb8e) by the author. We’ve automatically listed it here on packages.mudlet.org so more users can discover and benefit from it. Please let us know if you have any questions or concerns - thanks for contributing to the Mudlet community!]]"
+MudletWTTR.mpackage,config.lua,3,External Communications,https://,"mpackage = [[MudletWTTR]]
+author = [[Demonnic]]
+title = [[Get the weather from https://wttr.in in a miniconsole]]
+description = [[# MudletWTTR
+"
+MudletWTTR.mpackage,config.lua,7,External Communications,https://,"
+This is a fun and silly package I threw together for displaying weather reports in a Mudlet miniconsole.
+It uses https://wttr.in to get the reports and then just runs it through ansi2decho to push to the miniconsole.
+
+## Commands"
+simple-script-for-slothmud-ships.mpackage,config.lua,9,External Communications,https://,"
+---
+This package was originally shared on the [Mudlet Forums](https://forums.mudlet.org/viewtopic.php?f=6&t=3205&sid=9e9ab92edb9715ef63adb48743a4b4bb) by the author. We’ve automatically listed it here on packages.mudlet.org so more users can discover and benefit from it. Please let us know if you have any questions or concerns - thanks for contributing to the Mudlet community!]]"
+achaea-subdivisions-data-collecter.mpackage,config.lua,9,External Communications,https://,"
+---
+This package was originally shared on the [Mudlet Forums](https://forums.mudlet.org/viewtopic.php?f=6&t=2456&sid=aa12bbf669d90e2a5a6be5d034a5a4ba) by the author. We’ve automatically listed it here on packages.mudlet.org so more users can discover and benefit from it. Please let us know if you have any questions or concerns - thanks for contributing to the Mudlet community!]]"
+monk-custom-tekura-combos-achaea.mpackage,config.lua,9,External Communications,https://,"
+---
+This package was originally shared on the [Mudlet Forums](https://forums.mudlet.org/viewtopic.php?f=6&t=2188&sid=7fcf9295181de03042a95c0a4aa533eb) by the author. We’ve automatically listed it here on packages.mudlet.org so more users can discover and benefit from it. Please let us know if you have any questions or concerns - thanks for contributing to the Mudlet community!]]"


### PR DESCRIPTION
## Summary
- add AGENTS instructions for scanning
- implement `scan_packages.py` to inspect Lua files in packages
- include a sample `scan_report.csv` with first 10 detections

## Testing
- `python3 -m py_compile scan_packages.py`
- `python3 scan_packages.py`

------
https://chatgpt.com/codex/tasks/task_e_6885925ead088323b30832f161281d1f