### PR TITLE
Add requirements file and scan instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,22 @@ Contribute your mpackage using Github's "[fork and pull request](https://docs.gi
 
 Using Docker, run `./mpkg/muddle` or run Muddler [manually](https://github.com/demonnic/muddler/wiki/Installation) to generate the new `./mpkg/build/mpkg.mpackage` file can be loaded into Mudlet as a module.
 
+### Running Scans ###
+
+Install the Python dependencies before executing `scan_packages.py` or
+`scripts/security_scan.py`:
+
+```bash
+pip install -r requirements.txt
+```
+
+Then run either script as needed:
+
+```bash
+python scan_packages.py
+python scripts/security_scan.py
+```
+
 ### New `mpkg` release
 
 To make a new mpkg release, bump the version in [mpkg/mfile](mpkg/mfile) and the rest will happen automatically.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+dnspython


### PR DESCRIPTION
## Summary
- document how to run scanning scripts
- add a requirements.txt with dnspython for `scan_packages.py`

## Testing
- `python -m py_compile scan_packages.py scripts/security_scan.py`
- `pip install -r requirements.txt`
- `python scan_packages.py`
- `python scripts/security_scan.py --throttle 0`

------
https://chatgpt.com/codex/tasks/task_e_6886a39a34e88323896a3f42ffcd1604