### PR TITLE
Document suspicious Mudlet functions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,5 +9,6 @@
 - The scanner strips Lua comments before matching to avoid false positives from commented-out code.
 - Detection logic skips lines that define functions such as `openUrl = function(...)` to avoid false positives.
 - Network detection now matches `require('socket.http')`, `socket.http.request` and similar calls rather than any URL string. It also checks for Mudlet helper functions like `getHTTP`, `postHTTP`, `putHTTP`, `deleteHTTP`, `customHTTP`, `openWebPage`, `openUrl`, `downloadFile`, `installPackage`, `uninstallPackage`, and `unzipAsync`.
+- See [docs/suspicious-functions.md](docs/suspicious-functions.md) for a summary of these functions and why they are flagged.
 - Literal URLs and IP addresses are flagged unless they appear in package `description` blocks.
 - FQDNs are checked via DNS lookups; unresolved domains are flagged as `Unregistered` and domains on known public hosting providers are marked as `Publicly Writable`.

--- a/docs/suspicious-functions.md
+++ b/docs/suspicious-functions.md
@@ -1,0 +1,19 @@
+# Mudlet Functions with Network or Installation Side Effects
+
+The scanner looks for Lua functions that may perform downloading, installation, or other network activity. These functions were identified from **Mudlet** documentation (stored in `docs/MudletDocs` when present) and are targeted because they can modify a user's system or communicate over the internet.
+
+| Function | Purpose |
+|----------|---------|
+| `downloadFile(url, path)` | Downloads data from a URL to a local file. |
+| `getHTTP(url)` | Performs an HTTP GET request. |
+| `postHTTP(url, data)` | Sends an HTTP POST request. |
+| `putHTTP(url, data)` | Sends an HTTP PUT request. |
+| `deleteHTTP(url)` | Sends an HTTP DELETE request. |
+| `customHTTP(opts)` | Performs a custom HTTP request with user-specified options. |
+| `openWebPage(url)` | Opens a web page in the user's default browser. |
+| `openUrl(url)` | Alias of `openWebPage`. |
+| `installPackage(source)` | Installs a Mudlet package, optionally downloading it from a URL. |
+| `uninstallPackage(name)` | Removes an installed Mudlet package. |
+| `unzipAsync(zipfile, dest)` | Unpacks a zip archive asynchronously. |
+
+Any package using these functions may warrant closer review, especially if they operate on external URLs or untrusted data.


### PR DESCRIPTION
## Summary
- list Mudlet functions with networking/installation side effects
- link the new doc from AGENTS.md so contributors know what is being scanned

## Testing
- `python -m py_compile scan_packages.py scripts/security_scan.py`


------
https://chatgpt.com/codex/tasks/task_e_6886afeb4c948323a937ae9c26e97cd2